### PR TITLE
Add freelancer toggle interaction on home page

### DIFF
--- a/escrow-frontend/app/page.tsx
+++ b/escrow-frontend/app/page.tsx
@@ -1,6 +1,16 @@
+"use client";
+
+import { useState } from "react";
+
 export default function Home() {
+  const [isFreelancerView, setIsFreelancerView] = useState(false);
+
   return (
-    <div className="min-h-screen bg-[#2f3136] text-white">
+    <div
+      className={`min-h-screen text-white ${
+        isFreelancerView ? "bg-green-700" : "bg-[#2f3136]"
+      }`}
+    >
       <header className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5 md:px-10">
         <p className="text-xl font-bold tracking-tight">EscrowFreelance</p>
         <div className="flex items-center gap-3">
@@ -21,12 +31,30 @@ export default function Home() {
 
       <main className="mx-auto flex w-full max-w-6xl flex-col items-center px-6 pb-20 pt-10 text-center md:px-10 md:pt-16">
         <div className="mb-8 inline-flex items-center overflow-hidden rounded-full border border-white/80 text-sm font-semibold">
-          <span className="bg-white px-5 py-2 text-[#2f3136]">Clients</span>
-          <span className="px-5 py-2">Freelancers</span>
+          <button
+            type="button"
+            onClick={() => setIsFreelancerView(false)}
+            className={`px-5 py-2 transition ${
+              isFreelancerView ? "text-white/90 hover:bg-white/10" : "bg-white text-[#2f3136]"
+            }`}
+          >
+            Clients
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsFreelancerView(true)}
+            className={`px-5 py-2 transition ${
+              isFreelancerView ? "bg-white text-green-700" : "text-white/90 hover:bg-white/10"
+            }`}
+          >
+            Freelancers
+          </button>
         </div>
 
         <h1 className="max-w-4xl text-5xl font-extrabold leading-tight tracking-tight md:text-7xl">
-          Pay the way your project needs.
+          {isFreelancerView
+            ? "be sure that you money is waiting for you"
+            : "Pay the way your project needs."}
         </h1>
         <p className="mt-6 max-w-2xl text-lg text-white/80 md:text-xl">
           Secure escrow payments for freelance work. Fund milestones, approve


### PR DESCRIPTION
### Motivation
- Make the Home screen interactive so clicking the `Freelancers` option visibly switches the interface to a freelancer view with a green background and updated hero text.
- Provide a quick visual cue for freelancers so they see the message `be sure that you money is waiting for you` when selecting that mode.

### Description
- Converted the home page to a client component by adding `"use client"` and importing `useState` in `app/page.tsx`.
- Added `isFreelancerView` state and two clickable buttons (Clients / Freelancers) to toggle the view in `app/page.tsx`.
- Applied conditional classes to change the page background to green (`bg-green-700`) when freelancer mode is active and updated the main heading to `be sure that you money is waiting for you` in that mode.
- Replaced the static `span` labels with accessible `button` elements and kept the Clients button to switch back to the default view.

### Testing
- Ran `npm run lint` and it completed successfully.
- Launched the dev server and executed an automated Playwright check that loaded `/`, clicked the `Freelancers` button, and captured a screenshot showing the green background and updated heading, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984908135a48332882b554bbd803036)