### PR TITLE
Match Clients/Freelancers button sizes and scale active state

### DIFF
--- a/escrow-frontend/src/app/page.tsx
+++ b/escrow-frontend/src/app/page.tsx
@@ -29,11 +29,14 @@ export default function Home() {
       </header>
 
       <main className="mx-auto flex w-full max-w-6xl flex-col items-center px-6 pb-20 pt-10 text-center md:px-10 md:pt-16">
-        <div className="mb-8 inline-flex items-center overflow-hidden rounded-full border border-white/80 text-sm font-semibold">
+        <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-white/80 p-1 text-sm font-semibold">
           <button
             type="button"
             onClick={() => setIsFreelancerView(false)}
-            className={`px-5 py-2 transition ${isFreelancerView ? "text-white/90 hover:bg-white/10" : "bg-white text-[#2f3136]"
+            className={`w-36 rounded-full px-5 py-2 text-center transition duration-300 ${
+              isFreelancerView
+                ? "text-white/90 hover:bg-white/10"
+                : "scale-125 bg-white text-[#2f3136]"
               }`}
           >
             Clients
@@ -41,7 +44,10 @@ export default function Home() {
           <button
             type="button"
             onClick={() => setIsFreelancerView(true)}
-            className={`px-5 py-2 transition ${isFreelancerView ? "bg-white text-green-700" : "text-white/90 hover:bg-white/10"
+            className={`w-36 rounded-full px-5 py-2 text-center transition duration-300 ${
+              isFreelancerView
+                ? "scale-125 bg-white text-green-700"
+                : "text-white/90 hover:bg-white/10"
               }`}
           >
             Freelancers


### PR DESCRIPTION
### Motivation
- Ensure the "Clients" and "Freelancers" toggle buttons share the same base size and alignment so the UI looks balanced. 
- Provide a clear interactive cue by enlarging the selected role by 25% to indicate active state.

### Description
- Updated the toggle container to `mb-8 inline-flex items-center gap-2 rounded-full border border-white/80 p-1 text-sm font-semibold` to stabilize spacing when a button grows. 
- Set both buttons to a fixed base width and alignment using `w-36 rounded-full px-5 py-2 text-center`. 
- Added dynamic active styling so the selected button uses `scale-125` while the inactive button uses the normal scale, and applied a smooth transition with `transition duration-300`. 
- Modified `escrow-frontend/src/app/page.tsx` to implement these changes.

### Testing
- Ran `npm run lint` which completed successfully. 
- Launched the dev server and verified the UI rendered and behaved as expected, noting Next.js warnings about downloading Google Fonts but the page rendered with fallback fonts. 
- Captured automated screenshots of the default and "Freelancers"-selected states via a Playwright script to validate the toggle visuals (screenshots produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984977d21788332beda976f21caa149)