### PR TITLE
Show only wallet icons in login modal

### DIFF
--- a/escrow-frontend/src/app/page.tsx
+++ b/escrow-frontend/src/app/page.tsx
@@ -1,10 +1,17 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
 
 export default function Home() {
   const [isFreelancerView, setIsFreelancerView] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const wallets = [
+    { name: "MetaMask", icon: "/wallets/metamaskIcon.svg" },
+    { name: "Coinbase", icon: "/wallets/coinbaseIcon.svg" },
+    { name: "Phantom", icon: "/wallets/phantomIcon.svg" },
+    { name: "WalletConnect", icon: "/wallets/walletConnectIcon.svg" },
+  ];
 
   return (
     <div
@@ -125,18 +132,14 @@ export default function Home() {
             </div>
 
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              {[
-                "MetaMask",
-                "Coinbase",
-                "Phantom",
-                "WalletConnect",
-              ].map((wallet) => (
+              {wallets.map(({ name, icon }) => (
                 <button
-                  key={wallet}
+                  key={name}
                   type="button"
-                  className="rounded-xl border border-white/15 bg-[#162334] px-3 py-4 text-sm font-semibold text-white/90 transition hover:bg-[#1b2d43]"
+                  aria-label={name}
+                  className="flex items-center justify-center rounded-xl border border-white/15 bg-[#162334] px-3 py-4 text-sm font-semibold text-white/90 transition hover:bg-[#1b2d43]"
                 >
-                  {wallet}
+                  <Image src={icon} alt={name} width={20} height={20} />
                 </button>
               ))}
             </div>


### PR DESCRIPTION
### Motivation
- Simplify the login modal UI by showing only wallet provider icons for a cleaner, more compact appearance while preserving accessibility.

### Description
- Remove visible wallet name labels from each provider button and render only the `Image` icon, add `aria-label` with the provider name, center the icon by updating the button classes, and generate buttons from the `wallets` array.

### Testing
- Started the dev server with `npm run dev` (Next.js reported Ready), captured a Playwright screenshot of the login modal at `artifacts/login-wallet-icons-only.png`, and ran `npm run lint`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69859e9d03d08332ae82898ec78230aa)