### PR TITLE
Guard WalletConnect config when project id is missing

### DIFF
--- a/escrow-frontend/src/wagmi.ts
+++ b/escrow-frontend/src/wagmi.ts
@@ -2,6 +2,8 @@ import { createConfig, http } from "wagmi";
 import { sepolia } from "wagmi/chains";
 import { coinbaseWallet, injected, walletConnect } from "wagmi/connectors";
 
+const walletConnectProjectId = process.env.NEXT_PUBLIC_WC_PROJECT_ID;
+
 export const config = createConfig({
   chains: [sepolia],
   connectors: [
@@ -9,9 +11,13 @@ export const config = createConfig({
     coinbaseWallet({
       appName: "Escrow App",
     }),
-    walletConnect({
-      projectId: process.env.NEXT_PUBLIC_WC_PROJECT_ID!,
-    }),
+    ...(walletConnectProjectId
+      ? [
+          walletConnect({
+            projectId: walletConnectProjectId,
+          }),
+        ]
+      : []),
   ],
   transports: {
     [sepolia.id]: http(),


### PR DESCRIPTION
### Motivation
- Prevent app startup crashes when `NEXT_PUBLIC_WC_PROJECT_ID` is unset by avoiding creation of a `walletConnect` connector with an undefined `projectId`.

### Description
- In `src/wagmi.ts` add `walletConnectProjectId = process.env.NEXT_PUBLIC_WC_PROJECT_ID` and conditionally include the `walletConnect({...})` connector using a spread so it is only added when the env var is defined.

### Testing
- No automated tests were run for this change; the patch was committed and the updated file was manually inspected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c883bc6c833289f4337fffcf555a)